### PR TITLE
fix: do not ref group

### DIFF
--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -12,7 +12,7 @@ set -ouex pipefail
 # this installs a package from fedora repos
 dnf5 install -y tmux 
 
-dnf5 -y group remove gnome-desktop
+dnf5 -y group remove gdm gnome-shell gnome-session
 
 dnf5 copr enable -y ryanabx/cosmic-epoch
 dnf5 -y install @cosmic-desktop @cosmic-desktop-apps

--- a/build_files/build.sh
+++ b/build_files/build.sh
@@ -12,7 +12,7 @@ set -ouex pipefail
 # this installs a package from fedora repos
 dnf5 install -y tmux 
 
-dnf5 -y group remove gdm gnome-shell gnome-session
+dnf5 -y remove gdm gnome-shell gnome-session
 
 dnf5 copr enable -y ryanabx/cosmic-epoch
 dnf5 -y install @cosmic-desktop @cosmic-desktop-apps


### PR DESCRIPTION
Removing the GNOME group did not work.
Not attempting to remove it via the package names themselves.